### PR TITLE
Add GitHub Action for screenshot after page build

### DIFF
--- a/.github/workflows/screenshot-action.yml
+++ b/.github/workflows/screenshot-action.yml
@@ -1,0 +1,15 @@
+name: Screenshot After Page Build
+
+on:
+  page_build:
+
+jobs:
+  take-screenshot:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v2
+      - name: Take photo of github.com
+        uses: lannonbr/puppeteer-screenshot-action@1.0.0
+        with:
+          url: 'https://github.com'


### PR DESCRIPTION
Introduce a new GitHub Action to take a screenshot of 'https://github.com' using the puppeteer-screenshot-action@1.0.0 after the page_build event completes.