### PR TITLE
Update GitHub Action for Haiku Snapshot

### DIFF
--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -1,0 +1,14 @@
+name: Haiku Snapshot
+on: [push]
+jobs:
+  take-screenshot:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Haiku Snapshot
+      uses: 'lannonbr/puppeteer-screenshot-action@1.0.0'
+      env:
+        ACTIONS_ALLOW_UNSECURE_COMMANDS: true
+      with:
+        url: 'https://llminate-labs.github.io/haiku/'


### PR DESCRIPTION
This change updates the GitHub Actions workflow step to take a snapshot of the Haiku gallery using Puppeteer Screenshot Action.