### PR TITLE
Add Seasonal Themes to Haiku Display

### DIFF
--- a/haikuManager.js
+++ b/haikuManager.js
@@ -58,6 +58,7 @@ function stopRotation() {
 document.addEventListener('DOMContentLoaded', function() {
   updateHaiku();
   if (autoRotate) startRotation();
+  applySeasonalTheme();
 });
 
 document.getElementById('newHaikuBtn').addEventListener('click', incrementHaikuIndex);
@@ -91,4 +92,19 @@ function decrementHaikuIndex() {
   }
   updateHaiku();
   if (autoRotate) startRotation();
+}
+
+function applySeasonalTheme() {
+  const month = new Date().getMonth();
+  let season;
+  if (month >= 2 && month <= 4) {
+    season = 'spring';
+  } else if (month >= 5 && month <= 7) {
+    season = 'summer';
+  } else if (month >= 8 && month <= 10) {
+    season = 'autumn';
+  } else {
+    season = 'winter';
+  }
+  document.documentElement.setAttribute('data-theme', season);
 }

--- a/styles.css
+++ b/styles.css
@@ -8,11 +8,12 @@ body { font-family: 'Merriweather', serif; text-align: center; color: #2c3e50; h
 
 /* Dynamic Background Changes */
 html[data-theme='spring'] { background: linear-gradient(to top, #ffecd2 0%, #ffadd8 100%); }
+html[data-theme='summer'] { background: linear-gradient(to top, #f6d365 0%, #fda085 100%); }
+html[data-theme='autumn'] { background: linear-gradient(to top, #ff9a9e 0%, #fad0c4 100%); }
 html[data-theme='winter'] { background: linear-gradient(to top, #91e5f6 0%, #f2fcfe 100%); }
 html[data-theme='morning'] { background: linear-gradient(to top, #fde8c8 0%, #fad0c4 100%); }
 html[data-theme='ocean'] { background: linear-gradient(to top, #a1c4fd 0%, #c2e9fb 100%); }
 html[data-theme='mountain'] { background: linear-gradient(to top, #83a4d4 0%, #b6fbff 100%); }
-html[data-theme='autumn'] { background: linear-gradient(to top, #ff9a9e 0%, #fad0c4 100%); }
 
 /* Enhance button aesthetics */
 #newHaikuBtn, #prevHaikuBtn, #buyHaikuBtn { background-color: #3498db; border-radius: 15px; box-shadow: 0 2px 5px rgba(0,0,0,0.1); transition: all 0.3s ease; }


### PR DESCRIPTION
Enhance the haiku display by adding seasonal themes that change the background and styling based on the current season. This will make the website more dynamic and visually appealing.

**Tasks:**
1. Identify and design themes for each season (Spring, Summer, Autumn, Winter).
2. Implement CSS changes to reflect the seasonal themes.
3. Update the JavaScript to automatically detect the current season and apply the corresponding theme.
4. Test the seasonal themes to ensure they display correctly and enhance the user experience.

**Acceptance Criteria:**
- Seasonal themes are correctly identified and applied based on the current date.
- The website's appearance changes dynamically with the seasons.
- User feedback on the seasonal themes is positive.