### PR TITLE
Add Social Sharing Features

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,10 +22,17 @@
       <p id='haiku' tabindex='0'>Loading Haikus...</p>
       <img id='haikuImage' src='' alt='Haiku Image' style='max-width: 100%; height: auto;'>
       <button id='buyHaikuBtn' role='button' tabindex='0'>Buy This Haiku</button>
+      <!-- Social Sharing Buttons -->
+      <div class='social-sharing'>
+        <a href='#' class='share-btn facebook' onclick='shareOnFacebook()'>Share on Facebook</a>
+        <a href='#' class='share-btn twitter' onclick='shareOnTwitter()'>Share on Twitter</a>
+        <a href='#' class='share-btn instagram' onclick='shareOnInstagram()'>Share on Instagram</a>
+      </div>
     </div>
   </div>
   <script src='haikuManager.js' defer></script>
   <script src='purchaseManager.js' defer></script>
+  <script src='socialSharing.js' defer></script>
 </body>
 
 </html>

--- a/socialSharing.js
+++ b/socialSharing.js
@@ -1,0 +1,16 @@
+function shareOnFacebook() {
+  const haikuText = document.getElementById('haiku').innerText;
+  const url = 'https://www.facebook.com/sharer/sharer.php?u=' + encodeURIComponent(document.location.href) + '&quote=' + encodeURIComponent(haikuText);
+  window.open(url, '_blank');
+}
+
+function shareOnTwitter() {
+  const haikuText = document.getElementById('haiku').innerText;
+  const url = 'https://twitter.com/intent/tweet?url=' + encodeURIComponent(document.location.href) + '&text=' + encodeURIComponent(haikuText);
+  window.open(url, '_blank');
+}
+
+function shareOnInstagram() {
+  // Instagram does not support direct sharing via URL, this function will guide users
+  alert('To share on Instagram, please save the haiku image and post it manually.');
+}


### PR DESCRIPTION
Implemented social sharing buttons for Facebook, Twitter, and Instagram on the haiku display page. Users can now easily share their favorite haikus on these platforms, increasing visibility and engagement.

closes #123 