### PR TITLE
Add Relevant Image to the Haiku Image Placeholder

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@
       <button id='newHaikuBtn' role='button' tabindex='0'>Next Haiku</button>
     </div>
     <div id='haikuContainer' role='region' aria-live='polite'>
-      <img id='haikuImage' src='' alt='Haiku Image' style='max-width: 100%; height: auto; margin-bottom: 20px;'>
+      <img id='haikuImage' src='' alt='Haiku Image' style='max-width: 100%; height: auto; margin-bottom: 20px; display: block;'>
       <p id='haiku' tabindex='0'>Loading Haikus...</p>
       <button id='buyHaikuBtn' role='button' tabindex='0'>Buy This Haiku</button>
       <!-- Social Sharing Buttons -->

--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@
       <button id='newHaikuBtn' role='button' tabindex='0'>Next Haiku</button>
     </div>
     <div id='haikuContainer' role='region' aria-live='polite'>
-      <img id='haikuImage' src='' alt='Haiku Image' style='max-width: 100%; height: auto; margin-bottom: 20px; display: block;'>
+      <img id='haikuImage' src='https://oaidalleapiprodscus.blob.core.windows.net/private/org-xoveDohUTeWTwd7uYScv2uyz/user-7E63qmNDGeNd8DOac52nI0qL/img-i58r5iM0wf38smlR5Xepb3kU.png?st=2024-07-13T06%3A43%3A46Z&se=2024-07-13T08%3A43%3A46Z&sp=r&sv=2023-11-03&sr=b&rscd=inline&rsct=image/png&skoid=6aaadede-4fb3-4698-a8f6-684d7786b067&sktid=a48cca56-e6da-484e-a814-9c849652bcb3&skt=2024-07-13T03%3A16%3A33Z&ske=2024-07-14T03%3A16%3A33Z&sks=b&skv=2023-11-03&sig=Ftmw1kPFbNw8w3HMkuUqRLU%2BoKE/RdvxtFOph9SWHfs%3D' alt='Haiku Image' style='max-width: 100%; height: auto; margin-bottom: 20px; display: block;'>
       <p id='haiku' tabindex='0'>Loading Haikus...</p>
       <button id='buyHaikuBtn' role='button' tabindex='0'>Buy This Haiku</button>
       <!-- Social Sharing Buttons -->

--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@
       <button id='newHaikuBtn' role='button' tabindex='0'>Next Haiku</button>
     </div>
     <div id='haikuContainer' role='region' aria-live='polite'>
-      <img id='haikuImage' src='https://oaidalleapiprodscus.blob.core.windows.net/private/org-xoveDohUTeWTwd7uYScv2uyz/user-7E63qmNDGeNd8DOac52nI0qL/img-i58r5iM0wf38smlR5Xepb3kU.png?st=2024-07-13T06%3A43%3A46Z&se=2024-07-13T08%3A43%3A46Z&sp=r&sv=2023-11-03&sr=b&rscd=inline&rsct=image/png&skoid=6aaadede-4fb3-4698-a8f6-684d7786b067&sktid=a48cca56-e6da-484e-a814-9c849652bcb3&skt=2024-07-13T03%3A16%3A33Z&ske=2024-07-14T03%3A16%3A33Z&sks=b&skv=2023-11-03&sig=Ftmw1kPFbNw8w3HMkuUqRLU%2BoKE/RdvxtFOph9SWHfs%3D' alt='Haiku Image' style='max-width: 100%; height: auto; margin-bottom: 20px; display: block;'>
+      <img id='haikuImage' src='/.netlify/images?url=https://oaidalleapiprodscus.blob.core.windows.net/private/org-xoveDohUTeWTwd7uYScv2uyz/user-7E63qmNDGeNd8DOac52nI0qL/img-i58r5iM0wf38smlR5Xepb3kU.png?st=2024-07-13T06%3A43%3A46Z&se=2024-07-13T08%3A43%3A46Z&sp=r&sv=2023-11-03&sr=b&rscd=inline&rsct=image/png&skoid=6aaadede-4fb3-4698-a8f6-684d7786b067&sktid=a48cca56-e6da-484e-a814-9c849652bcb3&skt=2024-07-13T03%3A16%3A33Z&ske=2024-07-14T03%3A16%3A33Z&sks=b&skv=2023-11-03&sig=Ftmw1kPFbNw8w3HMkuUqRLU%2BoKE/RdvxtFOph9SWHfs%3D' alt='Haiku Image' style='max-width: 100%; height: auto; margin-bottom: 20px; display: block;'>
       <p id='haiku' tabindex='0'>Loading Haikus...</p>
       <button id='buyHaikuBtn' role='button' tabindex='0'>Buy This Haiku</button>
       <!-- Social Sharing Buttons -->

--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@
       <button id='newHaikuBtn' role='button' tabindex='0'>Next Haiku</button>
     </div>
     <div id='haikuContainer' role='region' aria-live='polite'>
-      <img id='haikuImage' src='/.netlify/images?url=https://oaidalleapiprodscus.blob.core.windows.net/private/org-xoveDohUTeWTwd7uYScv2uyz/user-7E63qmNDGeNd8DOac52nI0qL/img-i58r5iM0wf38smlR5Xepb3kU.png?st=2024-07-13T06%3A43%3A46Z&se=2024-07-13T08%3A43%3A46Z&sp=r&sv=2023-11-03&sr=b&rscd=inline&rsct=image/png&skoid=6aaadede-4fb3-4698-a8f6-684d7786b067&sktid=a48cca56-e6da-484e-a814-9c849652bcb3&skt=2024-07-13T03%3A16%3A33Z&ske=2024-07-14T03%3A16%3A33Z&sks=b&skv=2023-11-03&sig=Ftmw1kPFbNw8w3HMkuUqRLU%2BoKE/RdvxtFOph9SWHfs%3D' alt='Haiku Image' style='max-width: 100%; height: auto; margin-bottom: 20px; display: block;'>
+      <img id='haikuImage' src='/.netlify/images?url=https%3A%2F%2Foaidalleapiprodscus.blob.core.windows.net%2Fprivate%2Forg-xoveDohUTeWTwd7uYScv2uyz%2Fuser-7E63qmNDGeNd8DOac52nI0qL%2Fimg-i58r5iM0wf38smlR5Xepb3kU.png%3Fst%3D2024-07-13T06%253A43%253A46Z%26se%3D2024-07-13T08%253A43%253A46Z%26sp%3Dr%26sv%3D2023-11-03%26sr%3Db%26rscd%3Dinline%26rsct%3Dimage%2Fpng%26skoid%3D6aaadede-4fb3-4698-a8f6-684d7786b067%26sktid%3Da48cca56-e6da-484e-a814-9c849652bcb3%26skt%3D2024-07-13T03%253A16%253A33Z%26ske%3D2024-07-14T03%253A16%253A33Z%26sks%3Db%26skv%3D2023-11-03%26sig%3DFtmw1kPFbNw8w3HMkuUqRLU%252BoKE%2FRdvxtFOph9SWHfs%253D' alt='Haiku Image' style='max-width: 100%; height: auto; margin-bottom: 20px; display: block;'>
       <p id='haiku' tabindex='0'>Loading Haikus...</p>
       <button id='buyHaikuBtn' role='button' tabindex='0'>Buy This Haiku</button>
       <!-- Social Sharing Buttons -->


### PR DESCRIPTION
This pull request adds a visually appealing and contextually relevant image to the haiku image placeholder on the homepage. The image is intended to enhance the visual appeal and make the page more engaging. Closes issue #177.