### PR TITLE
Enhance 'Buy This Haiku' Button Design

### DIFF
--- a/buttonStyles.css
+++ b/buttonStyles.css
@@ -20,3 +20,22 @@
   outline: none; /* Remove default outline */ 
   box-shadow: 0 0 0 3px rgba(108, 117, 125, 0.5); /* Custom focus outline */ 
 }
+
+/* Enhanced design for 'Buy This Haiku' button */
+#buyHaikuBtn {
+  background-color: #28a745; /* Vibrant Green */
+  background-image: linear-gradient(145deg, #2ecc71, #27ae60); /* Gradient effect */
+  box-shadow: 0 4px 6px rgba(0,0,0,0.1), 0 1px 3px rgba(0,0,0,0.08); /* Enhanced shadow */
+  transition: all 0.3s ease-in-out;
+}
+
+#buyHaikuBtn:hover {
+  background-color: #218838; /* Darker Green on hover */
+  background-image: linear-gradient(145deg, #2ecc71, #27ae60); /* Gradient effect */
+  box-shadow: 0 6px 8px rgba(0,0,0,0.2), 0 2px 4px rgba(0,0,0,0.10); /* Stronger shadow on hover */
+  transform: translateY(-2px); /* Slight lift on hover */
+}
+
+#buyHaikuBtn:focus {
+  box-shadow: 0 0 0 3px rgba(40, 167, 69, 0.5); /* Custom focus outline */
+}


### PR DESCRIPTION
Closes #185

Enhanced the 'Buy This Haiku' button by adding a more vibrant green color, incorporating a gradient, and adding a slight shadow to make it more visually appealing. Also added hover and focus effects for better interaction.